### PR TITLE
Add "some overlap" category to Authors

### DIFF
--- a/categories.md
+++ b/categories.md
@@ -96,12 +96,13 @@ Possibilities:
 3. Overlap with missing names (subset)
 4. Overlap with extra values (actual person names)
 5. Overlap with extra values (noise / not actual names)
-6. No overlap (empty result set)
-7. No overlap (extraneous data)
+6. Some overlap, with both missing names and extra values
+8. No overlap (empty result set)
+9. No overlap (extraneous data)
 
 Questions:
 
-- How to detect automatically whether a name is a person's name or not?
+- How to detect automatically whether a name is a person's name or not? Is this even necessary for the evaluation?
 - How to take persons' roles into account?
 - How to score "correct name with incorrect structure" (first and last name inverted, missing first name...)
 


### PR DESCRIPTION
I suggest adding another category for the case when there is some overlap between the gold standard author set and the suggested author set, but it's neither a subset or a superset. Example:

    correct: ["Doe, John", "Doe, Jane"]
    suggestion: ["Doe, Jane", "Average, Joe"]